### PR TITLE
Advanced Setup without External Access functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ I'm using this myself for 5 chromecast devices: Lenovo Smart Display 8 & four 1s
 1. **Home Assistant**
 
 2. **[HTTPS External Access](https://www.makeuseof.com/secure-home-assistant-installation-free-ssl-certificate/?newsletter_popup=1)** which HA requires for casting and the HACS Addon installed. **Alternatively, if you have a Nabu Casa subscription then this is already set up for you.**
+    - *This **does** work without external access if you are behind a valid SSL cert locally*
 
 2. **Trusted network setup** for each Chromecast device to avoid logging in. See guide [here](https://blog.fuzzymistborn.com/homeassistant-and-catt-cast-all-the-things/) and follow the 'Trusted Networks' section half way down. You can either do your entire home network, or individual devices. You can find the IP address for each device by going to Settings -> Device Information -> Technical Information on the device.
 


### PR DESCRIPTION
I validated that with a valid SSL certificate I can use this to cast successful to a Nest Hub 2 without issue.

```
continuously_casting_dashboards:
  logging_level: warning #Required: Set the logging level - debug/info/warning (default is 'warning' - try 'debug' for debugging)
  cast_delay: 45 #Required: Time (in seconds) for casting checks between each device.
  start_time: "07:00" #Optional: Global start time of the casting window (format: "HH:MM") - Default is set to "07:00" and can be individually overwritten per device below.
  end_time: "01:00" #Optional: Global end time of the casting window (format: "HH:MM") and must be after "00:00". Default is set to "01:00" and can be individually overwritten per device below.
  devices:
    "<Display_Name>": #Required: Display name or IP address of your device. Find this on the actual device's settings or inside the Google Home app.
      - dashboard_url: "https://valid-ssl-cert-fqdn.com" #Required: Dashboard URL to be casted (This must be the local IP address of your HA instance, not homeassistant.local)
        volume: 5 #Optional: Volume to set the display. (If you remove this, the device will remain the same volume)
        start_time: "07:00" #Optional: Set the start time for this device
        end_time: "01:00" #Optional: Set the end time for this device
```